### PR TITLE
Add vertical split option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ cargo build --release && \
 rm -rf build/partydeck-rs
 mkdir -p build/ build/res && \
 cp target/release/partydeck-rs res/PartyDeckKWinLaunch.sh build/ && \
-cp res/splitscreen_kwin.js build/res
+cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js build/res

--- a/res/splitscreen_kwin_vertical.js
+++ b/res/splitscreen_kwin_vertical.js
@@ -1,0 +1,75 @@
+scrwidth = workspace.activeScreen.geometry.width;
+scrheight = workspace.activeScreen.geometry.height;
+
+Xpos_1p = [0];
+Ypos_1p = [0];
+Xsize_1p = [scrwidth];
+Ysize_1p = [scrheight];
+
+// Vertical split (side by side)
+Xpos_2p = [0, scrwidth / 2];
+Ypos_2p = [0, 0];
+Xsize_2p = [scrwidth / 2, scrwidth / 2];
+Ysize_2p = [scrheight, scrheight];
+
+Xpos_3p = [0, 0, scrwidth / 2];
+Ypos_3p = [0, scrheight / 2, scrheight / 2];
+Xsize_3p = [scrwidth, scrwidth / 2, scrwidth / 2];
+Ysize_3p = [scrheight / 2, scrheight / 2, scrheight / 2];
+
+Xpos_4p = [0, scrwidth / 2, 0, scrwidth / 2];
+Ypos_4p = [0, 0, scrheight / 2, scrheight / 2];
+Xsize_4p = [scrwidth / 2, scrwidth / 2, scrwidth / 2, scrwidth / 2];
+Ysize_4p = [scrheight / 2, scrheight / 2, scrheight / 2, scrheight / 2];
+
+function gamescopeSplitscreen(){
+    var allClients = workspace.windowList();
+    var gamescopeClients = []
+
+    for (var i = 0; i < allClients.length; i++){
+        if (allClients[i].resourceClass == 'gamescope'){
+            gamescopeClients.push(allClients[i]);
+        }
+    }
+    switch (gamescopeClients.length){
+        case 0:
+            return;
+        case 1:
+            var Xpos = Xpos_1p;
+            var Ypos = Ypos_1p;
+            var Xsize = Xsize_1p;
+            var Ysize = Ysize_1p;
+            break;
+        case 2:
+            var Xpos = Xpos_2p;
+            var Ypos = Ypos_2p;
+            var Xsize = Xsize_2p;
+            var Ysize = Ysize_2p;
+            break;
+        case 3:
+            var Xpos = Xpos_3p;
+            var Ypos = Ypos_3p;
+            var Xsize = Xsize_3p;
+            var Ysize = Ysize_3p;
+            break;
+        case 4:
+            var Xpos = Xpos_4p;
+            var Ypos = Ypos_4p;
+            var Xsize = Xsize_4p;
+            var Ysize = Ysize_4p;
+            break;
+    }
+
+    for (var i = 0; i < gamescopeClients.length; i++){
+        gamescopeClients[i].noBorder = true;
+        gamescopeClients[i].frameGeometry = {
+            x: Xpos[i],
+            y: Ypos[i],
+            width: Xsize[i],
+            height: Ysize[i]
+        };
+    }
+}
+
+workspace.windowAdded.connect(gamescopeSplitscreen);
+workspace.windowRemoved.connect(gamescopeSplitscreen);

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -295,6 +295,10 @@ impl PartyApp {
             &mut self.options.gamescope_sdl_backend,
             "Use SDL backend for Gamescope",
         );
+        let vertical_two_player_check = ui.checkbox(
+            &mut self.options.vertical_two_player,
+            "Vertical split for 2 players",
+        );
 
         if force_sdl2_check.hovered() {
             self.infotext = "Forces games to use the version of SDL2 included in the Steam Runtime. Only works on native Linux games, may fix problematic game controller support (incorrect mappings) in some games, may break others. If unsure, leave this unchecked.".to_string();
@@ -304,6 +308,11 @@ impl PartyApp {
         }
         if gamescope_sdl_backend_check.hovered() {
             self.infotext = "Runs gamescope sessions using the SDL backend. If unsure, leave this checked. If gamescope sessions only show a black screen or give an error (especially on Nvidia + Wayland), try disabling this.".to_string();
+        }
+        if vertical_two_player_check.hovered() {
+            self.infotext =
+                "Splits two-player games vertically (side by side) instead of horizontally."
+                    .to_string();
         }
 
         ui.horizontal(|ui| {
@@ -643,7 +652,12 @@ impl PartyApp {
         let cmd = launch_from_handler(handler, &self.pads, &self.players, &self.options)?;
         println!("\nCOMMAND:\n{}\n", cmd);
 
-        kwin_dbus_start_script(PATH_RES.join("splitscreen_kwin.js"))?;
+        let script = if self.players.len() == 2 && self.options.vertical_two_player {
+            "splitscreen_kwin_vertical.js"
+        } else {
+            "splitscreen_kwin.js"
+        };
+        kwin_dbus_start_script(PATH_RES.join(script))?;
 
         std::process::Command::new("sh")
             .arg("-c")
@@ -661,7 +675,12 @@ impl PartyApp {
 
         let cmd = launch_executable(path, &self.pads, &self.players, &self.options)?;
 
-        kwin_dbus_start_script(PATH_RES.join("splitscreen_kwin.js"))?;
+        let script = if self.players.len() == 2 && self.options.vertical_two_player {
+            "splitscreen_kwin_vertical.js"
+        } else {
+            "splitscreen_kwin.js"
+        };
+        kwin_dbus_start_script(PATH_RES.join(script))?;
 
         std::process::Command::new("sh")
             .arg("-c")

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -12,6 +12,8 @@ pub struct PartyConfig {
     pub render_scale: i32,
     pub gamescope_sdl_backend: bool,
     pub proton_version: String,
+    #[serde(default)]
+    pub vertical_two_player: bool,
 }
 
 pub fn load_cfg() -> PartyConfig {
@@ -29,6 +31,7 @@ pub fn load_cfg() -> PartyConfig {
         render_scale: 100,
         gamescope_sdl_backend: true,
         proton_version: "".to_string(),
+        vertical_two_player: false,
     }
 }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -95,7 +95,8 @@ pub fn launch_from_handler(
         let path_prof = &format!("{party}/profiles/{}", p.profname.as_str());
         let path_save = &format!("{path_prof}/saves/{}", h.uid.as_str());
 
-        let (gsc_width, gsc_height) = get_instance_resolution(players.len(), i, width, height);
+        let (gsc_width, gsc_height) =
+            get_instance_resolution(players.len(), i, width, height, cfg.vertical_two_player);
 
         if gsc_height < 600 && res_warn {
             msg(
@@ -245,7 +246,8 @@ pub fn launch_executable(
 
     cmd.push_str(&format!("cd \"{gamedir}\"; "));
     for (i, p) in players.iter().enumerate() {
-        let (gsc_width, gsc_height) = get_instance_resolution(players.len(), i, width, height);
+        let (gsc_width, gsc_height) =
+            get_instance_resolution(players.len(), i, width, height, cfg.vertical_two_player);
 
         if gsc_height < 600 && res_warn {
             msg(

--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -39,10 +39,17 @@ pub fn get_instance_resolution(
     i: usize,
     basewidth: u32,
     baseheight: u32,
+    two_player_vertical: bool,
 ) -> (u32, u32) {
     let (w, h) = match playercount {
         1 => (basewidth, baseheight),
-        2 => (basewidth, baseheight / 2),
+        2 => {
+            if two_player_vertical {
+                (basewidth / 2, baseheight)
+            } else {
+                (basewidth, baseheight / 2)
+            }
+        }
         3 => {
             if i == 0 {
                 (basewidth, baseheight / 2)


### PR DESCRIPTION
## Summary
- add script for vertical 2-player splitscreen layout (doesn't make sense for more players)
- add config field `vertical_two_player`
- support checkbox for layout in settings
- choose splitscreen script based on setting
- pass setting to resolution helper
- update `get_instance_resolution` for vertical layout
- include new script in build

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: Unable to find libarchive)*
