### PR TITLE
Add async tasks and overlay for game launches

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PartyConfig {
     pub force_sdl: bool,
     pub render_scale: i32,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+#[derive(Clone)]
 pub struct Player {
     pub pad_index: usize,
     pub profname: String,
@@ -77,9 +78,6 @@ impl Gamepad {
     }
     pub fn vendor(&self) -> u16 {
         self.dev.input_id().vendor()
-    }
-    pub fn product(&self) -> u16 {
-        self.dev.input_id().product()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,31 +23,6 @@ fn main() -> eframe::Result {
     if PATH_PARTY.join("tmp").exists() {
         std::fs::remove_dir_all(PATH_PARTY.join("tmp")).unwrap();
     }
-    if !PATH_RES.join("umu-run").exists() {
-        msg(
-            "Downloading Dependencies",
-            "UMU Launcher not found in resources folder. PartyDeck uses UMU to launch Windows games with Proton. Click OK to automatically download from the internet.",
-        );
-        if let Err(e) = update_umu_launcher() {
-            println!("Failed to download UMU Launcher: {}", e);
-            msg("Error", &format!("Failed to download UMU Launcher: {}", e));
-            std::fs::remove_file(PATH_RES.join("umu-run")).unwrap();
-            return Ok(());
-        }
-    }
-    if !PATH_RES.join("goldberg_linux").exists() || !PATH_RES.join("goldberg_win").exists() {
-        msg(
-            "Downloading Dependencies",
-            "Goldberg Steam Emu not found in resources folder. PartyDeck uses Goldberg for LAN play. Click OK to automatically download from the internet.",
-        );
-        if let Err(e) = update_goldberg_emu() {
-            println!("Failed to download Goldberg: {}", e);
-            msg("Error", &format!("Failed to download Goldberg: {}", e));
-            std::fs::remove_dir_all(PATH_PARTY.join("goldberg_linux")).unwrap();
-            std::fs::remove_dir_all(PATH_PARTY.join("goldberg_win")).unwrap();
-            return Ok(());
-        }
-    }
 
     println!("\n[PARTYDECK] started\n");
 


### PR DESCRIPTION
## Summary
- manage dependency updates and game launches in background threads
- show a centered overlay with spinner and status text while tasks run
- implement PadInfo and generic PadRef trait for device lookup
- derive `Clone` for configuration and player structs
- remove unused `Gamepad::product` method

## Testing
- `cargo check`
