### PR TITLE
Improve GUI visuals with bigger tiles

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -8,6 +8,8 @@ use crate::util::*;
 
 use dialog::DialogBox;
 use eframe::egui::{self, Key, Ui};
+
+const GAME_ICON_SIZE: f32 = 64.0;
 use std::path::PathBuf;
 
 #[derive(Eq, PartialEq)]
@@ -303,16 +305,18 @@ impl PartyApp {
             ui.horizontal(|ui| {
                 ui.add(
                     egui::Image::new(game.icon())
-                        .max_width(16.0)
-                        .corner_radius(2),
+                        .fit_to_exact_size(egui::vec2(GAME_ICON_SIZE, GAME_ICON_SIZE))
+                        .maintain_aspect_ratio(true),
                 );
-                let btn = ui.selectable_value(&mut self.selected_game, i, game.name());
+                let label = egui::RichText::new(game.name()).size(20.0);
+                let btn = ui.selectable_label(self.selected_game == i, label);
                 if btn.has_focus() {
                     btn.scroll_to_me(None);
                 }
                 if btn.clicked() {
+                    self.selected_game = i;
                     self.cur_page = MenuPage::Game;
-                };
+                }
 
                 let popup_id = ui.make_persistent_id(format!("gamectx{}", i));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,20 @@ mod util;
 use crate::app::*;
 use crate::paths::*;
 use crate::util::*;
+use eframe::egui;
+
+fn apply_steamdeck_style(ctx: &egui::Context) {
+    let mut visuals = egui::Visuals::dark();
+    let accent = egui::Color32::from_rgb(0, 174, 239);
+    visuals.widgets.active.bg_fill = accent;
+    visuals.widgets.hovered.bg_fill = accent.gamma_multiply(0.8);
+    visuals.selection.bg_fill = accent;
+    ctx.set_visuals(visuals);
+
+    let mut style = (*ctx.style()).clone();
+    style.spacing.item_spacing = egui::vec2(8.0, 8.0);
+    ctx.set_style(style);
+}
 
 fn main() -> eframe::Result {
     std::fs::create_dir_all(PATH_PARTY.join("gamesyms"))
@@ -53,6 +67,7 @@ fn main() -> eframe::Result {
             // This gives us image support:
             egui_extras::install_image_loaders(&cc.egui_ctx);
             cc.egui_ctx.set_zoom_factor(scale);
+            apply_steamdeck_style(&cc.egui_ctx);
             Ok(Box::<PartyApp>::default())
         }),
     )


### PR DESCRIPTION
## Summary
- add constant for large game icons
- enlarge game list tiles and accent color theme
- apply a Steam Deck styled theme to egui

## Testing
- `cargo check` *(fails: libarchive.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b9a20d74832aba2a4cd252fb759e