### PR TITLE
Add dynamic game grid

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -42,6 +42,19 @@ impl Game {
             }
         }
     }
+
+    pub fn tile_image(&self) -> ImageSource {
+        match self {
+            Game::Executable { .. } => self.icon(),
+            Game::HandlerRef(handler) => {
+                if let Some(path) = handler.img_paths.first() {
+                    format!("file://{}", path.display()).into()
+                } else {
+                    self.icon()
+                }
+            }
+        }
+    }
 }
 
 pub fn scan_all_games() -> Vec<Game> {


### PR DESCRIPTION
## Summary
- implement `tile_image` for `Game`
- add new `display_game_grid` and use it in the games panel

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c17717c832a99b5832b10a21270