### PR TITLE
Fix layout compilation

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -16,6 +16,7 @@ pub enum MenuPage {
     Settings,
     Profiles,
     Game,
+    About,
     Players,
 }
 
@@ -76,16 +77,10 @@ impl eframe::App for PartyApp {
             }
             self.display_top_panel(ui);
         });
-        egui::SidePanel::left("games_panel")
-            .resizable(false)
-            .exact_width(200.0)
-            .show(ctx, |ui| {
-                if self.task.is_some() {
-                    ui.disable();
-                }
-                self.display_games_panel(ui);
-            });
-        if (self.cur_page != MenuPage::Main) && (self.cur_page != MenuPage::Players) {
+        if (self.cur_page != MenuPage::Main)
+            && (self.cur_page != MenuPage::Players)
+            && (self.cur_page != MenuPage::About)
+        {
             self.display_info_panel(ctx);
         }
         egui::CentralPanel::default().show(ctx, |ui| {
@@ -107,6 +102,9 @@ impl eframe::App for PartyApp {
                 }
                 MenuPage::Players => {
                     self.display_page_players(ui);
+                }
+                MenuPage::About => {
+                    self.display_page_about(ui);
                 }
             }
         });
@@ -218,6 +216,9 @@ impl PartyApp {
                 self.pads.clear();
                 self.pads = scan_evdev_gamepads();
             }
+            if ui.button("ℹ About").clicked() {
+                self.cur_page = MenuPage::About;
+            }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if ui.button("❌ Quit").clicked() {
                     ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
@@ -236,35 +237,6 @@ impl PartyApp {
                     "https://github.com/wunnr/partydeck-rs/tree/main?tab=License-2-ov-file",
                 );
             });
-        });
-    }
-
-    fn display_games_panel(&mut self, ui: &mut Ui) {
-        ui.add_space(6.0);
-        ui.horizontal(|ui| {
-            ui.heading("Games");
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui.button("➕").clicked() {
-                    if let Err(err) = add_game() {
-                        println!("Couldn't add game: {err}");
-                        msg("Error", &format!("Couldn't add game: {err}"));
-                    }
-                    let dir_tmp = PATH_PARTY.join("tmp");
-                    if dir_tmp.exists() {
-                        std::fs::remove_dir_all(&dir_tmp).unwrap();
-                    }
-                    self.games.clear();
-                    self.games = crate::game::scan_all_games();
-                }
-                if ui.button("🔄").clicked() {
-                    self.games.clear();
-                    self.games = crate::game::scan_all_games();
-                }
-            });
-        });
-        ui.separator();
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            self.display_game_list(ui);
         });
     }
 
@@ -360,16 +332,115 @@ impl PartyApp {
         }
     }
 
+    fn display_game_grid(&mut self, ui: &mut Ui) {
+        const TILE_SIZE: egui::Vec2 = egui::vec2(160.0, 90.0);
+        const MIN_GAP: f32 = 5.0;
+        const ROW_GAP: f32 = 24.0;
+
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            let mut refresh_games = false;
+
+            let available = ui.available_width();
+            let mut columns = ((available + MIN_GAP) / (TILE_SIZE.x + MIN_GAP)).floor() as usize;
+            columns = columns.max(1);
+
+            let mut gap = (available - columns as f32 * TILE_SIZE.x) / (columns + 1) as f32;
+            while gap < MIN_GAP && columns > 1 {
+                columns -= 1;
+                gap = (available - columns as f32 * TILE_SIZE.x) / (columns + 1) as f32;
+            }
+            if gap < MIN_GAP {
+                gap = MIN_GAP;
+            }
+
+            let mut index = 0usize;
+            while index < self.games.len() {
+                ui.horizontal(|row| {
+                    row.add_space(gap);
+                    for _ in 0..columns {
+                        if index >= self.games.len() {
+                            break;
+                        }
+                        let game = &self.games[index];
+                        row.vertical(|cell| {
+                            cell.set_width(TILE_SIZE.x);
+                            let btn = egui::ImageButton::new(
+                                egui::Image::new(game.tile_image()).fit_to_exact_size(TILE_SIZE),
+                            )
+                            .corner_radius(4.0);
+                            let resp = cell.add(btn);
+                            if resp.clicked() {
+                                self.selected_game = index;
+                                self.cur_page = MenuPage::Game;
+                            }
+                            resp.context_menu(|ui| {
+                                if ui.button("Remove").clicked() {
+                                    if yesno(
+                                        "Remove game?",
+                                        &format!("Are you sure you want to remove {}?", game.name()),
+                                    ) {
+                                        if let Err(err) = remove_game(game) {
+                                            println!("Failed to remove game: {}", err);
+                                            msg("Error", &format!("Failed to remove game: {}", err));
+                                        }
+                                        refresh_games = true;
+                                    }
+                                    ui.close_menu();
+                                }
+                                if let HandlerRef(h) = game {
+                                    if ui.button("Open Handler Folder").clicked() {
+                                        if std::process::Command::new("sh")
+                                            .arg("-c")
+                                            .arg(format!("xdg-open {}", h.path_handler.display()))
+                                            .status()
+                                            .is_err()
+                                        {
+                                            msg("Error", "Couldn't open handler folder!");
+                                        }
+                                        ui.close_menu();
+                                    }
+                                }
+                            });
+                            cell.label(game.name());
+                        });
+                        index += 1;
+                        if index < self.games.len() {
+                            row.add_space(gap);
+                        }
+                    }
+                });
+                ui.add_space(ROW_GAP);
+            }
+
+            if refresh_games {
+                self.games = scan_all_games();
+            }
+        });
+    }
+
     fn display_page_main(&mut self, ui: &mut Ui) {
-        ui.heading("Welcome to PartyDeck");
+        ui.horizontal(|ui| {
+            if ui.button("➕ Add Game").clicked() {
+                if let Err(err) = add_game() {
+                    println!("Couldn't add game: {err}");
+                    msg("Error", &format!("Couldn't add game: {err}"));
+                }
+                let dir_tmp = PATH_PARTY.join("tmp");
+                if dir_tmp.exists() {
+                    std::fs::remove_dir_all(&dir_tmp).unwrap();
+                }
+                self.games.clear();
+                self.games = scan_all_games();
+            }
+            if ui.button("🔄 Refresh").clicked() {
+                self.games.clear();
+                self.games = scan_all_games();
+            }
+        });
         ui.separator();
-        ui.label("Press SELECT/BACK or Tab to unlock gamepad navigation.");
-        ui.label("PartyDeck is in the very early stages of development; as such, you will likely encounter bugs, issues, and strange design decisions.");
-        ui.label("For debugging purposes, it's recommended to read terminal output (stdout) for further information on errors.");
-        ui.label("If you have found this software useful, consider donating to support further development!");
-        ui.hyperlink_to("Ko-fi", "https://ko-fi.com/wunner");
-        ui.label("If you've encountered issues or want to suggest improvements, criticism and feedback are always appreciated!");
-        ui.hyperlink_to("GitHub", "https://github.com/wunnr/partydeck-rs");
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            self.display_game_grid(ui);
+        });
     }
 
     fn display_page_settings(&mut self, ui: &mut Ui) {
@@ -570,6 +641,18 @@ impl PartyApp {
                     });
                 });
         }
+    }
+
+    fn display_page_about(&mut self, ui: &mut Ui) {
+        ui.heading("Welcome to PartyDeck");
+        ui.separator();
+        ui.label("Press SELECT/BACK or Tab to unlock gamepad navigation.");
+        ui.label("PartyDeck is in the very early stages of development; as such, you will likely encounter bugs, issues, and strange design decisions.");
+        ui.label("For debugging purposes, it's recommended to read terminal output (stdout) for further information on errors.");
+        ui.label("If you have found this software useful, consider donating to support further development!");
+        ui.hyperlink_to("Ko-fi", "https://ko-fi.com/wunner");
+        ui.label("If you've encountered issues or want to suggest improvements, criticism and feedback are always appreciated!");
+        ui.hyperlink_to("GitHub", "https://github.com/wunnr/partydeck-rs");
     }
 
     fn display_page_players(&mut self, ui: &mut Ui) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -42,6 +42,19 @@ impl Game {
             }
         }
     }
+
+    pub fn tile_image(&self) -> ImageSource {
+        match self {
+            Game::Executable { .. } => self.icon(),
+            Game::HandlerRef(handler) => {
+                if let Some(path) = handler.img_paths.first() {
+                    format!("file://{}", path.display()).into()
+                } else {
+                    self.icon()
+                }
+            }
+        }
+    }
 }
 
 pub fn scan_all_games() -> Vec<Game> {


### PR DESCRIPTION
## Summary
- implement new `display_game_grid` layout with dynamic columns
- keep About page information with navigation
- provide helper `tile_image` method for larger grid images

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `dialog` found)*


------
https://chatgpt.com/codex/tasks/task_e_685c5c17717c832a99b5832b10a21270