### PR TITLE
Enable Steam Input pairing and dropdown selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A split-screen game launcher for Linux/SteamOS
 - Steam multiplayer API is emulated, allowing for multiple instances of Steam games
 - Works with most game controllers without any additional setup, drivers, or third-party software
 - Uses sandboxing software to mask out controllers so that each game instance only detects the controller assigned to it, preventing input interference
+- Supports assigning individual mice or Steam Input trackpads to each player (Steam Input trackpads may appear as duplicate devices)
 - Profile support allows each player to have their own persistent save data, settings, and stats for games
 - Works out of the box on SteamOS
 
@@ -64,7 +65,7 @@ PartyDeck uses a few software layers to provide a console-like split-screen gami
 ## Known Issues, Limitations and To-dos
 
 - AppImages and Flatpaks are not supported yet for native Linux games. Handlers can only run regular executables inside folders.
-- "Console-like splitscreen experience" means single-screen and controllers only. Multi-monitor support is possible but will require a better understanding of the KWin Scripting API. Support for multiple keyboards and mice is also theoretically possible, but I'll have to look into how I would go about implementing it.
+- "Console-like splitscreen experience" means single-screen and controllers only. Multi-monitor support is possible but will require a better understanding of the KWin Scripting API. Multiple mice are now supported through evdev or Steam Input trackpads, but Steam Input may create duplicate mouse devices. Support for multiple keyboards is still unimplemented.
 - The launcher is built synchronously, meaning there isn't any visual indicators of progress or loading when things are happening, it will just freeze up. This obviously isn't ideal.
 - Controller navigation support in the launcher is super primitive; I'd love to try making a more controller-friendly, Big-Picture-style UI in the future, but have no immediate plans for it.
 - Games using Goldberg might have trouble discovering LAN games from other devices. If this happens, you can try adding a firewall rule for port 47584. If connecting two Steam Decks through LAN, their hostnames should be changed from the default "steamdeck".

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -2,7 +2,7 @@ use crate::app::config::*;
 use crate::game::{Game::*, *};
 use crate::handler::*;
 use crate::input::*;
-use crate::launch::{PadInfo, launch_executable, launch_from_handler};
+use crate::launch::{MouseInfo, PadInfo, launch_executable, launch_from_handler};
 use crate::paths::*;
 use crate::util::*;
 
@@ -25,6 +25,7 @@ pub struct PartyApp {
     pub cur_page: MenuPage,
     pub infotext: String,
     pub pads: Vec<Gamepad>,
+    pub mice: Vec<Mouse>,
     pub players: Vec<Player>,
     pub games: Vec<Game>,
     pub profiles: Vec<String>,
@@ -45,12 +46,14 @@ impl Default for PartyApp {
     fn default() -> Self {
         let opts = load_cfg();
         let pads = scan_evdev_gamepads(&opts.pad_filter_type);
+        let mice = scan_evdev_mice();
         Self {
             needs_update: check_for_partydeck_update(),
             options: opts,
             cur_page: MenuPage::Main,
             infotext: String::new(),
             pads,
+            mice,
             players: Vec::new(),
             games: scan_all_games(),
             profiles: Vec::new(),
@@ -219,6 +222,7 @@ impl PartyApp {
                 self.players.clear();
                 self.pads.clear();
                 self.pads = scan_evdev_gamepads(&self.options.pad_filter_type);
+                self.mice = scan_evdev_mice();
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if ui.button("❌ Quit").clicked() {
@@ -439,6 +443,7 @@ impl PartyApp {
             if r1.clicked() || r2.clicked() || r3.clicked() {
                 self.pads.clear();
                 self.pads = scan_evdev_gamepads(&self.options.pad_filter_type);
+                self.mice = scan_evdev_mice();
             }
         });
 
@@ -542,6 +547,7 @@ impl PartyApp {
                 };
                 self.pads.clear();
                 self.pads = scan_evdev_gamepads(&self.options.pad_filter_type);
+                self.mice = scan_evdev_mice();
             }
         });
     }
@@ -647,6 +653,15 @@ impl PartyApp {
 
         ui.separator();
 
+        ui.heading("Mice / Trackpads");
+        ui.separator();
+
+        for mouse in self.mice.iter() {
+            ui.label(format!("🖱 {} ({})", mouse.name(), mouse.path()));
+        }
+
+        ui.separator();
+
         ui.heading("Players");
         ui.separator();
 
@@ -662,7 +677,9 @@ impl PartyApp {
         });
 
         let mut i = 0;
-        for player in &mut self.players {
+        while i < self.players.len() {
+            let mut remove_player = false;
+            let player = &mut self.players[i];
             ui.horizontal(|ui| {
                 ui.label("👤");
                 if let HandlerRef(_) = cur_game!(self) {
@@ -675,10 +692,56 @@ impl PartyApp {
                 } else {
                     ui.label(format!("Player {}", i + 1));
                 }
-                ui.label(format!("🎮 {}", self.pads[player.pad_index].fancyname(),));
-                ui.small(format!("({})", self.pads[player.pad_index].path(),));
+                ui.label("🎮");
+                let mut pad_sel = player.mask_pad_index;
+                egui::ComboBox::from_id_salt(format!("pad_{i}")).show_index(
+                    ui,
+                    &mut pad_sel,
+                    self.pads.len(),
+                    |idx| self.pads[idx].fancyname().to_string(),
+                );
+                if pad_sel != player.mask_pad_index {
+                    player.mask_pad_index = pad_sel;
+                    if self.pads[pad_sel].vendor() == 0x28de {
+                        if let Some(phys) = self.pads.iter().position(|p| {
+                            p.event_num() == self.pads[pad_sel].event_num() && p.vendor() != 0x28de
+                        }) {
+                            player.pad_index = phys;
+                        } else {
+                            player.pad_index = pad_sel;
+                        }
+                    } else {
+                        player.pad_index = pad_sel;
+                    }
+                }
+                ui.small(format!("({})", self.pads[player.mask_pad_index].path(),));
+                let mut mouse_sel = player.mouse_index.map(|x| x + 1).unwrap_or(0);
+                egui::ComboBox::from_id_salt(format!("mouse_{i}")).show_index(
+                    ui,
+                    &mut mouse_sel,
+                    self.mice.len() + 1,
+                    |idx| {
+                        if idx == 0 {
+                            "No Mouse".to_string()
+                        } else {
+                            self.mice[idx - 1].name().to_string()
+                        }
+                    },
+                );
+                player.mouse_index = if mouse_sel == 0 {
+                    None
+                } else {
+                    Some(mouse_sel - 1)
+                };
+                if ui.button("❌").clicked() {
+                    remove_player = true;
+                }
             });
-            i += 1;
+            if remove_player {
+                self.players.remove(i);
+            } else {
+                i += 1;
+            }
         }
         if self.players.len() > 0 {
             ui.separator();
@@ -741,14 +804,25 @@ impl PartyApp {
 
     fn handle_gamepad_players(&mut self) {
         for (i, pad) in self.pads.iter_mut().enumerate() {
-            if !pad.enabled() || is_pad_in_players(i, &self.players) {
+            if is_pad_in_players(i, &self.players) {
                 continue;
             }
             match pad.poll() {
                 Some(PadButton::ABtn) => {
                     if self.players.len() < 4 {
+                        let mask_idx = self
+                            .pads
+                            .iter()
+                            .position(|p| p.event_num() == pad.event_num() && p.vendor() == 0x28de)
+                            .unwrap_or(i);
+                        let mouse_idx = self
+                            .mice
+                            .iter()
+                            .position(|m| m.event_num() == self.pads[mask_idx].event_num());
                         self.players.push(Player {
                             pad_index: i,
+                            mask_pad_index: mask_idx,
+                            mouse_index: mouse_idx,
                             profname: String::new(),
                             profselection: 0,
                         });
@@ -801,19 +875,30 @@ impl PartyApp {
                 enabled: p.enabled(),
             })
             .collect();
+        let mouse_infos: Vec<MouseInfo> = self
+            .mice
+            .iter()
+            .map(|m| MouseInfo {
+                path: m.path().to_string(),
+            })
+            .collect();
         let cfg = self.options.clone();
         self.cur_page = MenuPage::Main;
         self.spawn_task("Launching...", move || match game {
             HandlerRef(handler) => {
-                if let Err(err) =
-                    run_handler_game(handler, players.clone(), pad_infos.clone(), cfg.clone())
-                {
+                if let Err(err) = run_handler_game(
+                    handler,
+                    players.clone(),
+                    pad_infos.clone(),
+                    mouse_infos.clone(),
+                    cfg.clone(),
+                ) {
                     println!("{}", err);
                     msg("Launch Error", &format!("{err}"));
                 }
             }
             Executable { path, .. } => {
-                if let Err(err) = run_exec_game(path, players, pad_infos, cfg) {
+                if let Err(err) = run_exec_game(path, players, pad_infos, mouse_infos, cfg) {
                     println!("{}", err);
                     msg("Launch Error", &format!("{err}"));
                 }
@@ -832,6 +917,7 @@ fn run_handler_game(
     handler: Handler,
     players: Vec<Player>,
     pad_infos: Vec<PadInfo>,
+    mouse_infos: Vec<MouseInfo>,
     cfg: PartyConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = save_cfg(&cfg);
@@ -844,7 +930,7 @@ fn run_handler_game(
         create_symlink_folder(&handler)?;
     }
 
-    let cmd = launch_from_handler(&handler, &pad_infos, &players, &cfg)?;
+    let cmd = launch_from_handler(&handler, &pad_infos, &mouse_infos, &players, &cfg)?;
     println!("\nCOMMAND:\n{}\n", cmd);
 
     if cfg.enable_kwin_script {
@@ -875,11 +961,12 @@ fn run_exec_game(
     path: PathBuf,
     players: Vec<Player>,
     pad_infos: Vec<PadInfo>,
+    mouse_infos: Vec<MouseInfo>,
     cfg: PartyConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = save_cfg(&cfg);
 
-    let cmd = launch_executable(&path, &pad_infos, &players, &cfg)?;
+    let cmd = launch_executable(&path, &pad_infos, &mouse_infos, &players, &cfg)?;
 
     let script = if players.len() == 2 && cfg.vertical_two_player {
         "splitscreen_kwin_vertical.js"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,19 +1,32 @@
 use crate::app::PadFilterType;
+use std::path::Path;
 
 #[derive(Clone)]
 pub struct Player {
+    /// Index of the physical gamepad used to control the UI
     pub pad_index: usize,
+    /// Index of the gamepad that will be exposed to the game
+    pub mask_pad_index: usize,
+    pub mouse_index: Option<usize>,
     pub profname: String,
     pub profselection: usize,
 }
 
 pub fn is_pad_in_players(index: usize, players: &Vec<Player>) -> bool {
     for player in players {
-        if player.pad_index == index {
+        if player.pad_index == index || player.mask_pad_index == index {
             return true;
         }
     }
     false
+}
+
+fn parse_event_num(path: &str) -> u32 {
+    Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|s| s.trim_start_matches("event").parse().ok())
+        .unwrap_or(0)
 }
 
 use evdev::*;
@@ -22,6 +35,25 @@ pub struct Gamepad {
     path: String,
     dev: Device,
     enabled: bool,
+    event_num: u32,
+}
+
+pub struct Mouse {
+    path: String,
+    dev: Device,
+    event_num: u32,
+}
+
+impl Mouse {
+    pub fn name(&self) -> &str {
+        self.dev.name().unwrap_or_else(|| "")
+    }
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+    pub fn event_num(&self) -> u32 {
+        self.event_num
+    }
 }
 pub enum PadButton {
     Left,
@@ -50,6 +82,9 @@ impl Gamepad {
     }
     pub fn path(&self) -> &str {
         &self.path
+    }
+    pub fn event_num(&self) -> u32 {
+        self.event_num
     }
     pub fn poll(&mut self) -> Option<PadButton> {
         let mut btn: Option<PadButton> = None;
@@ -96,17 +131,20 @@ pub fn scan_evdev_gamepads(filter: &PadFilterType) -> Vec<Gamepad> {
             PadFilterType::NoSteamInput => dev.1.input_id().vendor() != 0x28de,
             PadFilterType::OnlySteamInput => dev.1.input_id().vendor() == 0x28de,
         };
+        let vendor = dev.1.input_id().vendor();
         let has_btn_south = dev
             .1
             .supported_keys()
             .map_or(false, |keys| keys.contains(KeyCode::BTN_SOUTH));
-        if has_btn_south {
+        if has_btn_south || vendor == 0x28de {
             if dev.1.set_nonblocking(true).is_err() {
                 println!("Failed to set non-blocking mode for {}", dev.0.display());
                 continue;
             }
+            let path = dev.0.to_str().unwrap().to_string();
             pads.push(Gamepad {
-                path: dev.0.to_str().unwrap().to_string(),
+                event_num: parse_event_num(&path),
+                path,
                 dev: dev.1,
                 enabled,
             });
@@ -117,20 +155,27 @@ pub fn scan_evdev_gamepads(filter: &PadFilterType) -> Vec<Gamepad> {
 }
 
 #[allow(dead_code)]
-pub fn scan_evdev_mice() -> Vec<Device> {
-    let mut mice: Vec<Device> = Vec::new();
+pub fn scan_evdev_mice() -> Vec<Mouse> {
+    let mut mice: Vec<Mouse> = Vec::new();
     for dev in evdev::enumerate() {
+        let vendor = dev.1.input_id().vendor();
         let has_btn_left = dev
             .1
             .supported_keys()
             .map_or(false, |keys| keys.contains(KeyCode::BTN_LEFT));
-        if has_btn_left {
+        if has_btn_left || vendor == 0x28de {
             if dev.1.set_nonblocking(true).is_err() {
                 println!("Failed to set non-blocking mode for {}", dev.0.display());
                 continue;
             }
-            mice.push(dev.1);
+            let path = dev.0.to_str().unwrap().to_string();
+            mice.push(Mouse {
+                event_num: parse_event_num(&path),
+                path,
+                dev: dev.1,
+            });
         }
     }
+    mice.sort_by_key(|m| m.path.clone());
     mice
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -13,10 +13,19 @@ pub struct PadInfo {
     pub enabled: bool,
 }
 
+#[derive(Clone)]
+pub struct MouseInfo {
+    pub path: String,
+}
+
 pub trait PadRef {
     fn path(&self) -> &str;
     fn vendor(&self) -> u16;
     fn enabled(&self) -> bool;
+}
+
+pub trait MouseRef {
+    fn path(&self) -> &str;
 }
 
 impl PadRef for Gamepad {
@@ -43,9 +52,22 @@ impl PadRef for PadInfo {
     }
 }
 
-pub fn launch_from_handler<P: PadRef>(
+impl MouseRef for Mouse {
+    fn path(&self) -> &str {
+        self.path()
+    }
+}
+
+impl MouseRef for MouseInfo {
+    fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+pub fn launch_from_handler<P: PadRef, M: MouseRef>(
     h: &Handler,
     all_pads: &[P],
+    all_mice: &[M],
     players: &Vec<Player>,
     cfg: &PartyConfig,
 ) -> Result<String, Box<dyn std::error::Error>> {
@@ -193,8 +215,15 @@ pub fn launch_from_handler<P: PadRef>(
         }
         // Mask out any gamepads that aren't this player's
         for (i, pad) in all_pads.iter().enumerate() {
-            if !pad.enabled() || p.pad_index != i {
+            if !pad.enabled() || p.mask_pad_index != i {
                 let path = pad.path();
+                binds.push_str(&format!("--bind /dev/null {path} "));
+            }
+        }
+        // Mask out any mice that aren't this player's
+        for (i, mouse) in all_mice.iter().enumerate() {
+            if p.mouse_index != Some(i) {
+                let path = mouse.path();
                 binds.push_str(&format!("--bind /dev/null {path} "));
             }
         }
@@ -228,9 +257,10 @@ pub fn launch_from_handler<P: PadRef>(
     Ok(cmd)
 }
 
-pub fn launch_executable<P: PadRef>(
+pub fn launch_executable<P: PadRef, M: MouseRef>(
     exec_path: &PathBuf,
     all_pads: &[P],
+    all_mice: &[M],
     players: &Vec<Player>,
     cfg: &PartyConfig,
 ) -> Result<String, Box<dyn std::error::Error>> {
@@ -304,8 +334,15 @@ pub fn launch_executable<P: PadRef>(
 
         // Mask out any gamepads that aren't this player's
         for (i, pad) in all_pads.iter().enumerate() {
-            if pad.vendor() == 0x28de || p.pad_index != i {
+            if pad.vendor() == 0x28de || p.mask_pad_index != i {
                 let path = pad.path();
+                binds.push_str(&format!("--bind /dev/null {path} "));
+            }
+        }
+        // Mask out any mice that aren't this player's
+        for (i, mouse) in all_mice.iter().enumerate() {
+            if p.mouse_index != Some(i) {
+                let path = mouse.path();
                 binds.push_str(&format!("--bind /dev/null {path} "));
             }
         }


### PR DESCRIPTION
## Summary
- trackpads and controllers share event numbers; detect these
- let players choose controllers via dropdown
- pair a Steam Input controller with its matching trackpad automatically
- mask devices based on the paired controller when launching games

## Testing
- ❌ `cargo check` *(failed: libarchive missing)*


------
https://chatgpt.com/codex/tasks/task_e_686bc2e84bdc832a9c8bc493e01c8134