### PR TITLE
Fix Steam Input pairing with unique id

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ On first launch, the app will automatically download UMU Launcher and Goldberg S
 Once in the main menu, click the + button to add a handler. Create profiles if you want to store save data, and have a look through the settings menu.
 
 ### Using Steam Input
-When Steam Input is enabled, each physical controller appears twice on the Players page: once as the regular device and once as the Steam Input device. The launcher matches them using the underlying physical path, so adding a player with the A button on the real controller automatically selects the correct Steam Input controller and trackpad. You can adjust the assignment at any time from the player dropdowns.
+When Steam Input is enabled, each physical controller appears twice on the Players page: once as the regular device and once as the Steam Input device. The launcher matches them using the underlying device path or unique ID, so adding a player with the A button on the real controller automatically selects the correct Steam Input controller and trackpad. You can adjust the assignment at any time from the player dropdowns.
 
 ## Building
 

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -704,7 +704,10 @@ impl PartyApp {
                     player.mask_pad_index = pad_sel;
                     if self.pads[pad_sel].vendor() == 0x28de {
                         if let Some(phys) = self.pads.iter().position(|p| {
-                            p.phys() == self.pads[pad_sel].phys() && p.vendor() != 0x28de
+                            p.vendor() != 0x28de
+                                && (p.phys() == self.pads[pad_sel].phys()
+                                    || (!self.pads[pad_sel].uniq().is_empty()
+                                        && p.uniq() == self.pads[pad_sel].uniq()))
                         }) {
                             player.pad_index = phys;
                         } else {
@@ -807,9 +810,9 @@ impl PartyApp {
             if is_pad_in_players(i, &self.players) {
                 continue;
             }
-            let (btn, phys) = {
+            let (btn, phys, uniq) = {
                 let pad = &mut self.pads[i];
-                (pad.poll(), pad.phys().to_string())
+                (pad.poll(), pad.phys().to_string(), pad.uniq().to_string())
             };
             match btn {
                 Some(PadButton::ABtn) => {
@@ -817,12 +820,18 @@ impl PartyApp {
                         let mask_idx = self
                             .pads
                             .iter()
-                            .position(|p| p.phys() == phys && p.vendor() == 0x28de)
+                            .position(|p| {
+                                p.vendor() == 0x28de
+                                    && (p.phys() == phys || (!uniq.is_empty() && p.uniq() == uniq))
+                            })
                             .unwrap_or(i);
                         let mouse_idx = self
                             .mice
                             .iter()
-                            .position(|m| m.phys() == self.pads[mask_idx].phys());
+                            .position(|m| {
+                                m.phys() == self.pads[mask_idx].phys()
+                                    || (!uniq.is_empty() && m.uniq() == self.pads[mask_idx].uniq())
+                            });
                         self.players.push(Player {
                             pad_index: i,
                             mask_pad_index: mask_idx,

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,6 +37,7 @@ pub struct Gamepad {
     enabled: bool,
     event_num: u32,
     phys: String,
+    uniq: String,
 }
 
 pub struct Mouse {
@@ -44,6 +45,7 @@ pub struct Mouse {
     dev: Device,
     event_num: u32,
     phys: String,
+    uniq: String,
 }
 
 impl Mouse {
@@ -58,6 +60,9 @@ impl Mouse {
     }
     pub fn phys(&self) -> &str {
         &self.phys
+    }
+    pub fn uniq(&self) -> &str {
+        &self.uniq
     }
 }
 pub enum PadButton {
@@ -113,6 +118,9 @@ impl Gamepad {
     }
     pub fn phys(&self) -> &str {
         &self.phys
+    }
+    pub fn uniq(&self) -> &str {
+        &self.uniq
     }
     pub fn poll(&mut self) -> Option<PadButton> {
         let mut btn: Option<PadButton> = None;
@@ -171,12 +179,14 @@ pub fn scan_evdev_gamepads(filter: &PadFilterType) -> Vec<Gamepad> {
             }
             let path = dev.0.to_str().unwrap().to_string();
             let phys = dev.1.physical_path().unwrap_or("").to_string();
+            let uniq = dev.1.unique_name().unwrap_or("").to_string();
             pads.push(Gamepad {
                 event_num: parse_event_num(&path),
                 path,
                 dev: dev.1,
                 enabled,
                 phys,
+                uniq,
             });
         }
     }
@@ -200,11 +210,13 @@ pub fn scan_evdev_mice() -> Vec<Mouse> {
             }
             let path = dev.0.to_str().unwrap().to_string();
             let phys = dev.1.physical_path().unwrap_or("").to_string();
+            let uniq = dev.1.unique_name().unwrap_or("").to_string();
             mice.push(Mouse {
                 event_num: parse_event_num(&path),
                 path,
                 dev: dev.1,
                 phys,
+                uniq,
             });
         }
     }


### PR DESCRIPTION
## Summary
- improve doc about Steam Input
- include unique device ID in input scanning
- match controllers using physical path or unique ID

## Testing
- `cargo check` *(fails: libarchive missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c2250bb8c832a87e60667a0713bb4