### PR TITLE
Fix MouseInfo import

### DIFF
--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -2,7 +2,8 @@ use dialog::{Choice, DialogBox};
 use std::error::Error;
 use std::path::PathBuf;
 
-use crate::input::{Player, MouseInfo};
+use crate::input::Player;
+use crate::launch::MouseInfo;
 use x11rb::connection::Connection;
 
 pub fn msg(title: &str, contents: &str) {


### PR DESCRIPTION
## Summary
- fix MouseInfo import path in util::sys

## Testing
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6871680e3608832ab3a5dbbd4aaa35ed