### PR TITLE
Fix lifetime for DualSense handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,16 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
+
+[[package]]
+name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
@@ -906,7 +916,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "memchr",
 ]
 
@@ -1068,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1236,15 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dualsense-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4801f4040ea7d783c2c1111df25fdca6eb033f211c2ed26882da31b0bfcfa48"
+dependencies = [
+ "hidapi",
+]
 
 [[package]]
 name = "ecolor"
@@ -1424,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406ac2a8c9eedf8af9ee1489bee9e50029278a6456c740f7454cf8a158abc816"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1553,7 @@ dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
  "libc",
- "nix",
+ "nix 0.29.0",
 ]
 
 [[package]]
@@ -1749,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
- "bytes",
+ "bytes 1.10.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2000,6 +2037,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hidapi"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2073,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "fnv",
  "itoa",
 ]
@@ -2034,7 +2084,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "http",
 ]
 
@@ -2044,7 +2094,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-core",
  "http",
  "http-body",
@@ -2063,7 +2113,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-channel",
  "futures-util",
  "h2",
@@ -2100,7 +2150,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2116,7 +2166,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-channel",
  "futures-util",
  "http",
@@ -2319,6 +2369,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ioctl-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2776,6 +2841,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes 0.4.12",
+ "cfg-if 0.1.10",
+ "gcc",
+ "libc",
+ "void",
+]
 
 [[package]]
 name = "nix"
@@ -3301,6 +3380,7 @@ version = "0.4.1"
 dependencies = [
  "compress-tools",
  "dialog",
+ "dualsense-rs",
  "eframe",
  "egui_extras",
  "env_logger",
@@ -3315,6 +3395,7 @@ dependencies = [
  "serde_json",
  "steamlocate",
  "tar",
+ "uinput",
  "walkdir",
  "x11rb",
  "zbus 5.6.0",
@@ -3864,7 +3945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
- "bytes",
+ "bytes 1.10.1",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -4667,7 +4748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
- "bytes",
+ "bytes 1.10.1",
  "libc",
  "mio",
  "pin-project-lite",
@@ -4701,7 +4782,7 @@ version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -4842,6 +4923,29 @@ dependencies = [
  "memoffset",
  "tempfile",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "uinput"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b074d55c90be32a89a063fe3f944c0ceed0a8e3291369a99809f18fa326685b"
+dependencies = [
+ "custom_derive",
+ "enum_derive",
+ "libc",
+ "nix 0.10.0",
+ "uinput-sys",
+]
+
+[[package]]
+name = "uinput-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aabddd8174ccadd600afeab346bb276cb1db5fafcf6a7c5c5708b8cc4b2cac7"
+dependencies = [
+ "ioctl-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4998,6 +5102,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
@@ -5530,6 +5640,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6027,7 +6146,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "rand 0.8.5",
  "serde",
@@ -6063,7 +6182,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ zbus = "5.5.0"
 zip = "2.6.1"
 steamlocate = "2.0.1"
 semver = "1.0.26"
+dualsense-rs = "0.6.0"
+uinput = { version = "0.1.3", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod input;
 mod launch;
 mod paths;
 mod util;
+mod touchpad;
 
 use crate::app::*;
 use crate::paths::*;
@@ -25,6 +26,7 @@ fn main() -> eframe::Result {
     }
 
     println!("\n[PARTYDECK] started\n");
+    let _ds_mice = touchpad::spawn_dualsense_mice();
 
     let fullscreen = std::env::args().any(|arg| arg == "--fullscreen");
 

--- a/src/touchpad.rs
+++ b/src/touchpad.rs
@@ -1,0 +1,79 @@
+use std::sync::{Arc, Mutex};
+use dualsense_rs::DualSense;
+use uinput::device::Device;
+use uinput::event::relative::Position;
+use uinput::event::controller::Mouse;
+
+/// Representation of a DualSense controller mapped to a virtual mouse.
+pub struct DualSenseMouse {
+    pub name: String,
+    #[allow(dead_code)]
+    device: Arc<Mutex<Device>>, // keep device alive
+    #[allow(dead_code)]
+    controller: DualSense,
+    #[allow(dead_code)]
+    handle: std::thread::JoinHandle<()>,
+}
+
+/// Scan for connected DualSense controllers and spawn a uinput mouse for each.
+pub fn spawn_dualsense_mice() -> Vec<DualSenseMouse> {
+    let mut out = Vec::new();
+    let mut index = 0;
+    for info in DualSense::list_devices() {
+        if info.vendor_id() != 0x054c {
+            continue;
+        }
+        let path = match info.path().to_str() {
+            Ok(p) => p.to_string(),
+            Err(_) => continue,
+        };
+        let mut ds = DualSense::new_path(&path);
+        let name = format!("pd-dualsense-mouse-{}", index);
+        let ui = uinput::default()
+            .and_then(|dev| {
+                dev.name(&name)
+                    .unwrap()
+                    .event(Mouse::Left)
+                    .unwrap()
+                    .event(Mouse::Right)
+                    .unwrap()
+                    .event(Position::X)
+                    .unwrap()
+                    .event(Position::Y)
+                    .unwrap()
+                    .create()
+            })
+            .expect("failed to create uinput device");
+        let ui = Arc::new(Mutex::new(ui));
+        let ui_x = ui.clone();
+        let ui_y = ui.clone();
+        let pos = Arc::new(Mutex::new((0u16, 0u16)));
+        let pos_x = pos.clone();
+        let pos_y = pos.clone();
+        let cbx: &'static _ = Box::leak(Box::new(move |x| {
+            let mut p = pos_x.lock().unwrap();
+            let dx = x as i32 - p.0 as i32;
+            p.0 = x;
+            let _ = ui_x.lock().unwrap().position(&Position::X, dx);
+            let _ = ui_x.lock().unwrap().synchronize();
+        }));
+        ds.on_touchpad1_x_changed(cbx);
+        let cby: &'static _ = Box::leak(Box::new(move |y| {
+            let mut p = pos_y.lock().unwrap();
+            let dy = y as i32 - p.1 as i32;
+            p.1 = y;
+            let _ = ui_y.lock().unwrap().position(&Position::Y, dy);
+            let _ = ui_y.lock().unwrap().synchronize();
+        }));
+        ds.on_touchpad1_y_changed(cby);
+        let handle = ds.run();
+        out.push(DualSenseMouse {
+            name,
+            device: ui,
+            controller: ds,
+            handle,
+        });
+        index += 1;
+    }
+    out
+}


### PR DESCRIPTION
## Summary
- ensure DualSense touchpad callback closures live for `'static` lifetime
- update lockfile for new dualsense/uinput dependencies

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687184b72e60832a8b293897e67ad8be