### PR TITLE
Fix library path for PartyDeck

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,-rpath,$ORIGIN"]

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,7 @@ cargo build --release && \
 rm -rf build/partydeck-rs
 mkdir -p build/ build/res && \
 cp target/release/partydeck-rs res/PartyDeckKWinLaunch.sh build/ && \
-cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js res/gamescope build/res
+cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js build/res && \
+if [ -d res/gamescope ]; then cp -r res/gamescope build/res; fi && \
+libpath=$(find target/release/build -name libsteam_api.so | head -n 1) && \
+cp "$libpath" build/


### PR DESCRIPTION
## Summary
- add rpath settings so runtime libs load from executable dir
- copy libsteam_api.so into build directory
- avoid build failure if custom gamescope folder is missing

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68726dd9e498832a9f1e523e4facb262