### PR TITLE
Simplify input navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn main() -> eframe::Result {
             .with_inner_size([1080.0, 540.0])
             .with_min_inner_size([640.0, 360.0])
             .with_fullscreen(fullscreen)
+            .with_active(true)
             .with_icon(
                 eframe::icon_data::from_png_bytes(&include_bytes!("../res/icon.png")[..])
                     .expect("Failed to load icon"),


### PR DESCRIPTION
## Summary
- drop special controller shortcuts and use arrow keys
- request focus on startup window

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6872771242bc832aa74a8a9035d434de