### PR TITLE
Fix library path for PartyDeck

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,-rpath,$ORIGIN"]

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,7 @@ cargo build --release && \
 rm -rf build/partydeck-rs
 mkdir -p build/ build/res && \
 cp target/release/partydeck-rs res/PartyDeckKWinLaunch.sh build/ && \
-cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js res/gamescope build/res
+cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js build/res && \
+if [ -d res/gamescope ]; then cp -r res/gamescope build/res; fi && \
+libpath=$(find target/release/build -name libsteam_api.so | head -n 1) && \
+cp "$libpath" build/

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -468,7 +468,7 @@ impl PartyApp {
                         kbm_support: true,
                         proton_version: "".to_string(),
                         vertical_two_player: false,
-                        pad_filter_type: PadFilterType::NoSteamInput,
+                        pad_filter_type: PadFilterType::All,
                     };
                     self.input_devices = scan_input_devices(&self.options.pad_filter_type);
                     fill_steam_names(&mut self.input_devices);
@@ -952,14 +952,21 @@ impl PartyApp {
         ui.heading("Devices");
         ui.separator();
 
+        let mut deck_indices: Vec<usize> = Vec::new();
         for (i, pad) in self.input_devices.iter().enumerate() {
-            let label_type = if pad.is_steam_input() { "Steam Input" } else { "Real" };
+            if pad.is_steam_input() {
+                continue;
+            }
+            if pad.vendor() == 0x28de {
+                deck_indices.push(i);
+                continue;
+            }
+
             let mut dev_text = RichText::new(format!(
-                "{} {} ({}) - {}",
+                "{} {} ({})",
                 pad.emoji(),
-                pad.fancyname(),
-                pad.path(),
-                label_type
+                pad.name(),
+                pad.path()
             ))
             .small();
 
@@ -971,11 +978,29 @@ impl PartyApp {
 
             ui.label(dev_text);
 
-            if !pad.is_steam_input() {
+            if let Some(stds) = self.steam_map.get(&i) {
+                for sid in stds {
+                    let sdev = &self.input_devices[*sid];
+                    ui.label(RichText::new(format!("  ↳ {} {}", sdev.emoji(), sdev.fancyname())).small());
+                }
+            }
+        }
+
+        if !deck_indices.is_empty() {
+            ui.label(RichText::new("Steam Deck").strong());
+            for i in deck_indices {
+                let pad = &self.input_devices[i];
+                let mut dev_text = RichText::new(format!("  {} {} ({})", pad.emoji(), pad.name(), pad.path())).small();
+                if !pad.enabled() {
+                    dev_text = dev_text.weak();
+                } else if pad.has_button_held() {
+                    dev_text = dev_text.strong();
+                }
+                ui.label(dev_text);
                 if let Some(stds) = self.steam_map.get(&i) {
                     for sid in stds {
                         let sdev = &self.input_devices[*sid];
-                        ui.label(format!("  ↳ {} {}", sdev.emoji(), sdev.fancyname()));
+                        ui.label(RichText::new(format!("    ↳ {} {}", sdev.emoji(), sdev.fancyname())).small());
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add rpath settings so runtime libs load from executable dir
- copy libsteam_api.so into build directory
- avoid build failure if custom gamescope folder is missing
- list native device names and group Steam Deck inputs
- default controller filter includes all devices

## Testing
- no tests run due to small change

------
https://chatgpt.com/codex/tasks/task_e_68726dd9e498832a9f1e523e4facb262