### PR TITLE
Add dev setup docs and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Scope
+
+This file applies to the entire repository and provides guidance for the assistant working on pull requests.
+
+### Testing and Build Guidelines
+- Run `./build.sh` when changing more than ~20 lines of code or when modifying multiple modules.
+- Small changes under ~20 lines, such as documentation updates or minor tweaks, do not require running build or tests.
+- If there are tests available, run `cargo test` only after large code refactors or feature additions.
+
+### Commit Practices
+- Use `git status` to confirm a clean repository before and after commits.
+- Keep commit messages concise and descriptive.
+

--- a/DEV_ENV_SETUP.md
+++ b/DEV_ENV_SETUP.md
@@ -1,0 +1,36 @@
+# Developer Environment Setup
+
+This guide explains how to configure the environment for faster builds and smoother development with PartyDeck.
+
+## Dependencies
+- Install the latest stable Rust toolchain (`rustup install stable`).
+- Ensure `meson` and `ninja` are available for the `deps/gamescope` build.
+- On Debian-based distros, you can run:
+  ```bash
+  sudo apt-get update
+  sudo apt-get install -y build-essential meson ninja-build libx11-dev libxext-dev
+  ```
+- For additional dependencies, see the `README.md` build section.
+
+## Caching
+- Use Rust's incremental compilation (`CARGO_INCREMENTAL=1`) to speed up builds.
+- Consider using `sccache` for distributed caching if builds take a long time.
+
+## Quick Build Steps
+1. Initialize submodules:
+   ```bash
+   git submodule update --init
+   ```
+2. Build Gamescope for keyboard/mouse support:
+   ```bash
+   (cd deps/gamescope && meson setup build/ && ninja -C build/)
+   ```
+3. Build the main project:
+   ```bash
+   ./build.sh
+   ```
+
+## Notes
+- The `AGENTS.md` file in this repository outlines guidelines for the assistant about when to run builds and tests.
+- For minor documentation or single-line code changes, you can skip running the build script to save time.
+


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with build/test advice for the assistant
- document how to configure a fast development environment in `DEV_ENV_SETUP.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879518527ec832a9a7632ac45752a0b