### PR TITLE
Fix Steam Deck helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once in the main menu, click the + button to add a handler. Create profiles if y
 
 ## Building
 
-To build PartyDeck, You'll need a Rust toolchain installed with the 2024 Edition. For the mouse/keyboard gamescope build, you'll need ninja and meson installed.
+To build PartyDeck, you'll need a Rust toolchain installed with the 2024 Edition. For the mouse/keyboard gamescope build, you'll need Ninja and Meson installed.
 Clone the repo with submodules by running `git clone --recurse-submodules https://github.com/wunnr/partydeck-rs.git`. Navigate to the gamescope submodule at `deps/gamescope` and run these commands to build the mouse/keyboard gamescope:
 
 ```
@@ -57,6 +57,9 @@ meson setup build/
 ninja -C build/
 build/gamescope -- <game>
 ```
+
+If you're on a Steam Deck, run `./scripts/install_steamdeck_deps.sh` to
+install all required packages before running the above commands.
 
 Then, in the main partydeck folder, run `build.sh`. This will build the executable, and place it in the `build` folder, along with the relevant dependencies and resources.
 

--- a/scripts/install_steamdeck_deps.sh
+++ b/scripts/install_steamdeck_deps.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install build dependencies for PartyDeck and the bundled gamescope fork on SteamOS / Steam Deck.
+# Run this once before building.
+
+set -e
+
+if ! command -v pacman >/dev/null; then
+    echo "pacman not found. This script is intended for SteamOS" >&2
+    exit 1
+fi
+
+# allow writes to the system and update packages
+sudo steamos-readonly disable || true
+
+sudo pacman -Syu --needed --noconfirm \
+    base-devel meson ninja cmake git \
+    clang glslang libcap \
+    pipewire sdl2 vulkan-headers libdrm libx11 libxmu \
+    libxcomposite libxrender libxres libxtst libxkbcommon \
+    libinput wayland wayland-protocols hwdata \
+    libxdamage libdecor wlroots \
+    xorg-xwayland benchmark \
+    libavif libheif aom rav1e luajit
+
+cat <<'EOM'
+Dependencies installed. Build gamescope with:
+  cd deps/gamescope && meson setup build && ninja -C build
+Then run ./build.sh in the project root.
+EOM


### PR DESCRIPTION
## Summary
- fix missing `wlroots0.18` package by using `wlroots`
- clarify README usage of `install_steamdeck_deps.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68794bcbdafc832a9f3cc8e43ef6a3d2