### PR TITLE
Add debug player controls

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -342,6 +342,16 @@ impl PartyApp {
         }
     }
 
+    pub fn add_dummy_device(&mut self) {
+        self.input_devices.push(InputDevice {
+            path: "dummy".to_string(),
+            dev: None,
+            enabled: true,
+            device_type: DeviceType::Gamepad,
+            has_button_held: false,
+        });
+    }
+
     pub fn prepare_game_launch(&mut self) {
         let game = cur_game!(self).to_owned();
         let mut instances = self.instances.clone();

--- a/src/app/gui_pages.rs
+++ b/src/app/gui_pages.rs
@@ -19,6 +19,7 @@ impl PartyApp {
     pub fn display_page_main(&mut self, ui: &mut Ui) {
         ui.heading("Welcome to PartyDeck");
         ui.separator();
+
         ui.label("Press SELECT/BACK or Tab to unlock gamepad navigation.");
         ui.label("PartyDeck is in the very early stages of development; as such, you will likely encounter bugs, issues, and strange design decisions.");
         ui.label("For debugging purposes, it's recommended to read terminal output (stdout) for further information on errors.");
@@ -211,6 +212,14 @@ impl PartyApp {
         });
 
         ui.separator();
+
+        if ui.button("➕ Add Player").clicked() {
+            self.instances.push(Instance {
+                devices: Vec::new(),
+                profname: String::new(),
+                profselection: 0,
+            });
+        }
 
         let mut devices_to_remove = Vec::new();
         for (i, instance) in &mut self.instances.iter_mut().enumerate() {

--- a/src/app/gui_panels.rs
+++ b/src/app/gui_panels.rs
@@ -137,6 +137,10 @@ impl PartyApp {
 
             ui.label(dev_text);
         }
+
+        if ui.button("➕ Dummy Device").clicked() {
+            self.add_dummy_device();
+        }
     }
 
     pub fn panel_left_game_list(&mut self, ui: &mut Ui) {


### PR DESCRIPTION
## Summary
- allow adding instances with no controllers attached
- support a dummy input device for testing
- move `Add Player` option to the Instances page

## Testing
- `./build.sh` *(fails: libarchive not found)*

------
https://chatgpt.com/codex/tasks/task_e_687961ab856c832a91d61eb5950cad38