### PR TITLE
Improve Steam Deck build flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,18 @@ Once in the main menu, click the + button to add a handler. Create profiles if y
 
 ## Building
 
-To build PartyDeck, you'll need a Rust toolchain installed with the 2024 Edition. For the mouse/keyboard gamescope build, you'll need Ninja and Meson installed.
-Clone the repo with submodules by running `git clone --recurse-submodules https://github.com/wunnr/partydeck-rs.git`. Navigate to the gamescope submodule at `deps/gamescope` and run these commands to build the mouse/keyboard gamescope:
+To build PartyDeck you'll need a Rust toolchain with the 2024 edition. Clone the
+repository including submodules:
 
 ```
-git submodule update --init
-meson setup build/
-ninja -C build/
-build/gamescope -- <game>
+git clone --recurse-submodules https://github.com/wunnr/partydeck-rs.git
 ```
 
-If you're on a Steam Deck, run `./scripts/install_steamdeck_deps.sh` to
-install all required packages, including `libffi` and `libarchive`, before
-running the above commands.
-
-Then, in the main partydeck folder, run `build.sh`. This will build the executable, and place it in the `build` folder, along with the relevant dependencies and resources.
+On Steam Deck simply run `./build.sh`.
+The script automatically installs the required packages, builds the bundled
+Gamescope fork and then places the resulting binaries under `build`. During
+the process you can choose between a Deck-optimized build or a variant with
+keyboard and mouse support.
 
 
 ## How it Works

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,67 @@
 #!/bin/bash
 
-cargo build --release && \
+set -e
+
+build_gamescope() {
+    local enable_openvr=$1
+    if [ ! -f deps/gamescope/build/src/gamescope ]; then
+        echo "Building gamescope submodule..."
+        git submodule update --init --recursive
+        (
+            cd deps/gamescope && \
+            meson setup build/ -Denable_openvr_support="$enable_openvr" && \
+            ninja -C build/
+        )
+    fi
+}
+
+ensure_tools() {
+    for t in meson ninja; do
+        if ! command -v "$t" >/dev/null; then
+            echo "$t missing. Run scripts/install_steamdeck_deps.sh first." >&2
+            exit 1
+        fi
+    done
+}
+
+install_steamdeck_deps() {
+    if command -v pacman >/dev/null; then
+        echo "Installing Steam Deck dependencies..."
+        sudo steamos-readonly disable >/dev/null 2>&1 || true
+        sudo pacman -Syu --needed --noconfirm \
+            base-devel meson ninja cmake git \
+            clang glslang libcap \
+            pipewire sdl2 vulkan-headers libdrm libx11 libxmu \
+            libxcomposite libxrender libxres libxtst libxkbcommon \
+            libinput wayland wayland-protocols hwdata \
+            libxdamage libdecor wlroots libffi libarchive \
+            xorg-xwayland benchmark \
+            libavif libheif aom rav1e luajit
+    fi
+}
+
+echo "Select build variant:"
+echo " 1) Steam Deck (optimized)"
+echo " 2) Steam Deck with keyboard/mouse"
+read -p "Choice [1/2]: " choice
+
+install_steamdeck_deps
+ensure_tools
+
+if [ "$choice" = "2" ]; then
+    build_gamescope true
+else
+    build_gamescope false
+fi
+
+cargo build --release
+
 rm -rf build/partydeck-rs
-mkdir -p build/ build/res && \
-cp target/release/partydeck-rs res/PartyDeckKWinLaunch.sh build/ && \
-cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js build/res && \
+mkdir -p build/ build/res
+cp target/release/partydeck-rs res/PartyDeckKWinLaunch.sh build/
+cp res/splitscreen_kwin.js res/splitscreen_kwin_vertical.js build/res
 cp deps/gamescope/build/src/gamescope build/res
+
+if command -v pacman >/dev/null; then
+    sudo steamos-readonly enable >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
## Summary
- embed Steam Deck package installation in `build.sh`
- run `steamos-readonly` automatically when installing packages
- mention the new workflow in the README

## Testing
- `./build.sh` fails with message `meson missing. Run scripts/install_steamdeck_deps.sh first.`

------
https://chatgpt.com/codex/tasks/task_e_687a7602f100832a9ac8143ad10ac25d